### PR TITLE
rewriting lambda calculations and multiprocess gamma

### DIFF
--- a/correlogram/lambda_calc.py
+++ b/correlogram/lambda_calc.py
@@ -1,24 +1,27 @@
 from core.image import Image
 
-# recursive approach
-def horizontal_lambda(pixel, color, distance): # O(N) where distance=N
-  if pixel is None:
-    return 0
-  if distance == 0:
-    return int(pixel.color == color)
-
-  return horizontal_lambda(pixel, color, distance - 1) + horizontal_lambda(pixel + (distance, 0), color, 0)
-
-# iterative approach
-def vertical_lambda(pixel, color, distance): # like horizontal_lambda but in an imperative style.
+def vertical_lambda(pixel, distance): # like horizontal_lambda but in an imperative style.
   sum = 0
-  for d in range(distance + 1): # runs between 0 to distance inclusive
-    if pixel is None:
+  for i in range(0, 2 * distance - 1): # 0 ... 2k-2 times
+    y_index = pixel.y - distance + 1 + i
+    if y_index >= len(pixel.image.source) or y_index < 0:
       continue
-    p = pixel + (0, d)
-    if p is None:
+    if pixel.x - distance >= 0:
+      sum += int(pixel.color == pixel.image.source[y_index][pixel.x - distance])
+    if pixel.x + distance < len(pixel.image.source[0]):
+      sum += int(pixel.color == pixel.image.source[y_index][pixel.x + distance])
+
+  return sum
+
+def horizontal_lambda(pixel, distance): # like horizontal_lambda but in an imperative style.
+  sum = 0
+  for i in range(0, 2 * distance + 1): # 0 ... 2k times
+    x_index = pixel.x - distance + i
+    if x_index >= len(pixel.image.source[0]) or x_index < 0:
       continue
-    if p.color == color:
-      sum += 1
+    if pixel.y - distance >= 0:
+      sum += int(pixel.color == pixel.image.source[pixel.y - distance][x_index])
+    if pixel.y + distance < len(pixel.image.source):
+      sum += int(pixel.color == pixel.image.source[pixel.y + distance][x_index])
 
   return sum

--- a/main.py
+++ b/main.py
@@ -1,29 +1,17 @@
 #! /Users/yishaizehavi/.virtualenvs/cv/bin/python3
 
-import multiprocessing as mp
 from correlogram import specific_correlogram
 from utils.colors import get_unique_colors
 from adapters.cv_image import OpenCVImage
 from utils.log import log_time
-
-PROCESSES = mp.cpu_count() - 1
 
 @log_time
 def main():
   luffy = OpenCVImage('imgs/luffy.jpg')
   colors = get_unique_colors(luffy)
 
-  print(f'Running with {PROCESSES} processes!')
-  pool = mp.Pool(PROCESSES)
-
-  def cb(result):
-    for correlogram in result:
-      print(correlogram)
-
-  pool.starmap_async(specific_correlogram, map(lambda color: (luffy, color, color, 8), colors), callback=cb)
-    
-  pool.close()
-  pool.join()
+  for color in colors:
+    print(specific_correlogram(luffy, color, color, 8))
 
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
Improved results by more than 40%.

- Small image (luffy.jpg) took around 13 secs (previously: ~40 secs).
- Medium-Large image (ether.jpg) took around 70 secs (previously: ~180 secs).

closes #2 